### PR TITLE
fix(ci): add semantic release push permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -65,7 +65,7 @@ jobs:
       contents: write
       packages: write
     concurrency:
-      group: release
+      group: release-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - build
@@ -76,15 +76,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           node-version: lts/*
-      - run: npm clean-install
+      - run: HUSKY=0 npm ci
       - name: Run semantic-release
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npx semantic-release > semantic_release_output.txt || false
           cat semantic_release_output.txt
@@ -96,7 +98,7 @@ jobs:
   docs:
     concurrency:
       # Only one release job at a time. Strictly sequential.
-      group: docs
+      group: docs-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - release
@@ -132,7 +134,7 @@ jobs:
       contents: write
       packages: write
     concurrency:
-      group: deploy-image
+      group: deploy-image-${{ github.event.number || github.ref }}
     runs-on: ubuntu-latest
     needs:
       - release


### PR DESCRIPTION
This pull request updates the github token for semantic release, allowing it to push to main while the ci isn't passing yet.

